### PR TITLE
Add Nemo actions for deja-dup

### DIFF
--- a/nemo_actions/README.md
+++ b/nemo_actions/README.md
@@ -1,0 +1,6 @@
+# Nemo Actions
+
+A collection of nemo action scripts:
+
+- deja-dup_revert - reverts a file(s) from a deja-dup backups
+- deja-dup_restore - restores missing files in a directory from deja-dup backups

--- a/nemo_actions/deja-dup_restore-missing.nemo_action
+++ b/nemo_actions/deja-dup_restore-missing.nemo_action
@@ -1,0 +1,27 @@
+[Nemo Action]
+
+#########################################
+## PURPOSE:
+##
+## Provide Nemo equivalent for deja-dup's 
+## integration with GNOME / Nautilus 
+## to restore a directory of all missing
+## files from current backups
+##
+## Forked From:
+## https://github.com/erickj/nemo-actions
+#########################################
+
+# This file should be put into either
+# /usr/share/nemo/actions/
+# or
+# $HOME/.local/share/nemo/actions/
+
+Active=true
+Name=Restore Missing Files...
+Comment=Check for missing files or directories from backups
+Exec=/usr/bin/deja-dup --restore-missing '%F'
+Icon-Name=document-revert-rtl
+Selection=none
+Extensions=any;
+Dependencies=/usr/bin/deja-dup

--- a/nemo_actions/deja-dup_revert.nemo_action
+++ b/nemo_actions/deja-dup_revert.nemo_action
@@ -1,0 +1,26 @@
+[Nemo Action]
+
+#############################################
+## PURPOSE:
+##
+## Provide Nemo equivalent for deja-dup's 
+## integration with GNOME / Nautilus 
+## to restore an individual file from backups
+##
+## Forked From:
+## https://github.com/erickj/nemo-actions
+#############################################
+
+# This file should be put into either
+# /usr/share/nemo/actions/
+# or
+# $HOME/.local/share/nemo/actions/
+
+Active=true
+Name=Revert to Previous Version...
+Comment=Revert to a previous version from backups
+Exec=/usr/bin/deja-dup --restore '%F'
+Icon-Name=document-revert
+Selection=notnone
+Extensions=any;
+Dependencies=/usr/bin/deja-dup


### PR DESCRIPTION
This pull adds integration to Cinnamon's Nemo file manager with the backup application deja-dup. These two actions add context menu options 'Restore Missing Files' to folders and "Revert to Previous Version" to files within Nemo, which brings the Cinnamon version of deja-dup up to feature parity with GNOME.

We are planning to include deja-dup by default into future versions of Cinnamon Korora, and so its usage should be as easy as possible for the end-user. This implementation avoids the need for the end-user to drop into a terminal in order to use the backup restore features.